### PR TITLE
Only add sides to solids when extruding, ignore polygon edges that form internal edges with any other or same polygon

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1866,3 +1866,24 @@ fn test_flatten_and_union_debug() {
     assert!(!flattened.polygons.is_empty(), "Flattened square should not be empty");
     assert!(flattened.polygons[0].vertices.len() >= 3, "Should form at least a triangle");
 }
+
+#[test]
+fn test_extrude_faces_on_hull_only() {
+    let extruded_cube_geo = CSG::<()>::from_complex_polygons(&vec![vec![
+        vec![0., 0.],
+        vec![0., 1.],
+        vec![1., 1.],
+        vec![1., 0.],
+    ]])
+    .extrude(1.);
+
+    let triangles = extruded_cube_geo
+        .to_polygons()
+        .iter()
+        .flat_map(|poly| poly.triangulate());
+
+    assert_eq!(
+        triangles.count(),
+        6 /* sides of a cube */ * 2 /* triangles per side */
+    );
+}


### PR DESCRIPTION
Extrusion in extrude_vector with complex polygons requires that side polygons are only added to edges that form the hull of a polygon. This change discards all edges that are not part of the hull polygon before adding sides to the extruded solid.

This is an attempt to fix #4, there's still some things to do:
- [ ] extend this to `extrude_between`
- [ ] use a hashmap in order to prevent this from scaling in O(|edge|^2)
- [ ] recalculate vertex normals