### PR TITLE
use Shape

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use chull::ConvexHullWrapper;
 use parry3d_f64::{
     bounding_volume::Aabb,
     query::{Ray, RayCast},
-    shape::{Triangle, TriMesh, SharedShape},
+    shape::{Shape, SharedShape, TriMesh, Triangle},
     };
 use rapier3d_f64::prelude::*;
 use meshtext::{Glyph, MeshGenerator, MeshText};


### PR DESCRIPTION
The Shape trait needs to be in scope for `mass_properties`.

This does not seem to be an issue for rustc based on the order of use clauses. However, if one runs rustfmt (as many rust devs do automatically), this order is changed and rustc realizes that the Shape trait is missing and fails to compile this, which is a bit annoying.

(Alternatively, one could also run rustfmt on the whole library, which would also require one to use the Shape trait. But I realize that that's_ not up to me.)