### PR TITLE
Add explicit compile error for invalid tesselation mode feature flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub mod shapes3d;
 pub mod extrudes;
 pub mod io;
 
+#[cfg(any(all(feature = "delaunay", feature = "earcut"), not(any(feature = "delaunay", feature = "earcut"))))]
+compile_error!("Either 'delaunay' or 'earcut' feature must be specified, but not both");
+
 #[cfg(feature = "hashmap")]
 pub mod flatten_slice;
 


### PR DESCRIPTION
Either "delaunay" or "earcut" needs to be specified, but not both. The code would just give a confusing compile error otherwise.