### PR TITLE
Improve error handling with anyhow::Result to prevent stack overflow in Node::build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "approx"
@@ -328,6 +328,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 name = "csgrs"
 version = "0.17.0"
 dependencies = [
+ "anyhow",
  "chull",
  "contour_tracing",
  "core2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ opt-level = "z"
 lto = true
 
 [dependencies]
+anyhow = { version = "1.0.97" }
 # core2 = { version = "0.4.0", default_features = false, features = ["alloc"] } # no-std, still throws errors
 core2 = { version = "0.4.0", features = ["alloc"] }
 nalgebra = "0.33"

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -79,13 +79,11 @@ impl<S: Clone + Send + Sync> Node<S> {
 
         // For each polygon, split it by the node's plane.
         for poly in polygons {
-            plane.split_polygon(
-                poly,
-                &mut coplanar_front,
-                &mut coplanar_back,
-                &mut front,
-                &mut back,
-            );
+            let (cf, cb, f, b) = plane.split_polygon(poly);
+            coplanar_front.extend(cf);
+            coplanar_back.extend(cb);
+            front.extend(f);
+            back.extend(b);
         }
 
         // Now decide where to send the coplanar polygons.  If the polygon’s normal
@@ -258,19 +256,17 @@ impl<S: Clone + Send + Sync> Node<S> {
 
         // For each polygon, split it relative to the current node's plane.
         for p in polygons {
-            let mut coplanar_front = Vec::new();
-            let mut coplanar_back = Vec::new();
+            let (coplanar_front, coplanar_back, f, b) = plane.split_polygon(p);
 
-            plane.split_polygon(
-                p,
-                &mut coplanar_front,
-                &mut coplanar_back,
-                &mut front,
-                &mut back,
-            );
+            self.polygons.extend(coplanar_front);
+            self.polygons.extend(coplanar_back);
 
-            self.polygons.append(&mut coplanar_front);
-            self.polygons.append(&mut coplanar_back);
+            front.extend(f);
+            back.extend(b);
+        }
+
+        if front.len() == polygons.len() {
+        } else if back.len() == polygons.len() {
         }
 
         // Recursively build the front subtree.

--- a/src/csg.rs
+++ b/src/csg.rs
@@ -238,8 +238,8 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
     #[must_use = "Use new CSG representing space in both CSG's"]
     pub fn union(&self, other: &CSG<S>) -> anyhow::Result<CSG<S>> {
         // 3D union:
-        let mut a = Node::new(&self.polygons);
-        let mut b = Node::new(&other.polygons);
+        let mut a = Node::new(&self.polygons)?;
+        let mut b = Node::new(&other.polygons)?;
 
         a.clip_to(&b);
         b.clip_to(&a);
@@ -302,8 +302,8 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
     #[must_use = "Use new CSG"]
     pub fn difference(&self, other: &CSG<S>) -> anyhow::Result<CSG<S>> {
         // 3D difference:
-        let mut a = Node::new(&self.polygons);
-        let mut b = Node::new(&other.polygons);
+        let mut a = Node::new(&self.polygons)?;
+        let mut b = Node::new(&other.polygons)?;
 
         a.invert();
         a.clip_to(&b);
@@ -357,8 +357,8 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
     /// ```
     pub fn intersection(&self, other: &CSG<S>) -> anyhow::Result<CSG<S>> {
         // 3D intersection:
-        let mut a = Node::new(&self.polygons);
-        let mut b = Node::new(&other.polygons);
+        let mut a = Node::new(&self.polygons)?;
+        let mut b = Node::new(&other.polygons)?;
 
         a.invert();
         b.clip_to(&a);

--- a/src/flatten_slice.rs
+++ b/src/flatten_slice.rs
@@ -93,9 +93,9 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
     /// //   - Possibly an open or closed polygon(s) at z=0
     /// //   - Or empty if no intersection
     /// ```
-    pub fn slice(&self, plane: Plane) -> CSG<S> {
+    pub fn slice(&self, plane: Plane) -> anyhow::Result<CSG<S>> {
         // Build a BSP from all of our polygons:
-        let node = Node::new(&self.polygons.clone());
+        let node = Node::new(&self.polygons.clone())?;
 
         // Ask the BSP for coplanar polygons + intersection edges:
         let (coplanar_polys, intersection_edges) = node.slice(&plane);
@@ -142,11 +142,11 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
         }
 
         // Return a purely 2D CSG: polygons empty, geometry has the final shape
-        CSG {
+        Ok(CSG {
             polygons: Vec::new(),
             geometry: new_gc,
             metadata: self.metadata.clone(),
-        }
+        })
     }
     
     /// Checks if the CSG object is manifold.

--- a/src/io/svg.rs
+++ b/src/io/svg.rs
@@ -395,7 +395,7 @@ impl FromSVG for CSG<()> {
                         if ls.is_closed() {
                             let polygon = Polygon::new(ls, vec![]);
                             let csg = Self::from_geo(polygon.into(), None);
-                            csg_union = csg_union.union(&csg);
+                            csg_union = csg_union.union(&csg).unwrap();
                         }
                     }
                 },
@@ -410,7 +410,7 @@ impl FromSVG for CSG<()> {
 
                     let csg = Self::circle(r, segments, None)
                         .translate(cx, cy, 0.0);
-                    csg_union = csg_union.union(&csg);
+                    csg_union = csg_union.union(&csg).unwrap();
                 },
 
                 Event::Tag(tag::Rectangle, Empty, attrs) => {
@@ -429,7 +429,7 @@ impl FromSVG for CSG<()> {
 
                     let csg = Self::rounded_rectangle(w, h, r, segments, None)
                             .translate(x, y, 0.0);
-                    csg_union = csg_union.union(&csg);
+                    csg_union = csg_union.union(&csg).unwrap();
                 },
 
                 Event::Tag(tag::Ellipse, Empty, attrs) => {
@@ -443,7 +443,7 @@ impl FromSVG for CSG<()> {
 
                     let csg = Self::ellipse(rx * 2.0, ry * 2.0, segments, None)
                         .translate(cx, cy, 0.0);
-                    csg_union = csg_union.union(&csg);
+                    csg_union = csg_union.union(&csg).unwrap();
                 },
 
                 Event::Tag(tag::Line, Empty, attrs) => {
@@ -462,7 +462,7 @@ impl FromSVG for CSG<()> {
                         vec![],
                     );
                     let csg = Self::from_geo(polygon.into(), None);
-                    csg_union = csg_union.union(&csg);
+                    csg_union = csg_union.union(&csg).unwrap();
                 },
 
                 Event::Tag(tag::Polyline, Empty, attrs) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,15 +48,15 @@ fn main() {
     let _ = fs::write("stl/cube_mirrored_x.stl", mirrored_cube.to_stl_binary("cube_mirrored_x").unwrap());
 
     // 3) Boolean operations: Union, Subtract, Intersect
-    let union_shape = moved_cube.union(&sphere);
+    let union_shape = moved_cube.union(&sphere).unwrap();
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/union_cube_sphere.stl", union_shape.to_stl_binary("union_cube_sphere").unwrap());
 
-    let subtract_shape = moved_cube.difference(&sphere);
+    let subtract_shape = moved_cube.difference(&sphere).unwrap();
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/subtract_cube_sphere.stl", subtract_shape.to_stl_binary("subtract_cube_sphere").unwrap());
 
-    let intersect_shape = moved_cube.intersection(&sphere);
+    let intersect_shape = moved_cube.intersection(&sphere).unwrap();
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/intersect_cube_sphere.stl", intersect_shape.to_stl_binary("intersect_cube_sphere").unwrap());
 
@@ -189,7 +189,7 @@ fn main() {
 
     let sphere_test = CSG::sphere(1.0, 16, 8, None);
     let cube_test = CSG::cube(1.0, 1.0, 1.0, None);
-    let res = cube_test.difference(&sphere_test);
+    let res = cube_test.difference(&sphere_test).unwrap();
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/sphere_cube_test.stl", res.to_stl_binary("sphere_cube_test").unwrap());
     assert_eq!(res.bounding_box(), cube_test.bounding_box());
@@ -258,15 +258,15 @@ fn main() {
     
     // Distribute a square along an arc
     let square = CSG::circle(1.0, 32, None);
-    let arc_array = square.distribute_arc(5, 5.0, 0.0, 180.0);
+    let arc_array = square.distribute_arc(5, 5.0, 0.0, 180.0).unwrap();
     let _ = fs::write("stl/arc_array.stl", arc_array.to_stl_ascii("arc_array"));
     
     // Distribute that wedge along a linear axis
-    let wedge_line = wedge.distribute_linear(4, nalgebra::Vector3::new(1.0, 0.0, 0.0), 3.0);
+    let wedge_line = wedge.distribute_linear(4, nalgebra::Vector3::new(1.0, 0.0, 0.0), 3.0).unwrap();
     let _ = fs::write("stl/wedge_line.stl", wedge_line.to_stl_ascii("wedge_line"));
     
     // Make a 4x4 grid of the supershape
-    let grid_of_ss = sshape.distribute_grid(4, 4, 3.0, 3.0);
+    let grid_of_ss = sshape.distribute_grid(4, 4, 3.0, 3.0).unwrap();
     let _ = fs::write("stl/grid_of_ss.stl", grid_of_ss.to_stl_ascii("grid_of_ss"));
     
     // 1. Circle with keyway
@@ -458,7 +458,7 @@ fn main() {
             None::<()>,
         )
         .scale(0.05, 0.05, 0.05);
-        let scene = tri_2d.extrude(0.1).union(&arrow);
+        let scene = tri_2d.extrude(0.1).union(&arrow).unwrap();
         let _ = fs::write("stl/scene_right_triangle.stl", scene.to_stl_ascii("scene_right_triangle"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ fn main() {
     // 2) Slice at z=0
     #[cfg(feature = "hashmap")]
     {
-    let cross_section = cyl.slice(Plane { normal: Vector3::z(), w: 0.0 });
+    let cross_section = cyl.slice(Plane { normal: Vector3::z(), w: 0.0 }).unwrap();
     let _ = fs::write("stl/sliced_cylinder.stl", cyl.to_stl_ascii("sliced_cylinder"));
     let _ = fs::write("stl/sliced_cylinder_slice.stl", cross_section.to_stl_ascii("sliced_cylinder_slice"));
     }
@@ -504,7 +504,7 @@ fn main() {
     // Scene I: Demonstrate slice(plane) – slice a cube at z=0
     {
         let plane_z = Plane{ normal: Vector3::z(), w: 0.5 };
-        let sliced_polygons = cube.slice(plane_z);
+        let sliced_polygons = cube.slice(plane_z).unwrap();
         let _ = fs::write("stl/scene_sliced_cube.stl", cube.to_stl_ascii("sliced_cube"));
         // Save cross-section as well
         let _ = fs::write("stl/scene_sliced_cube_section.stl", sliced_polygons.to_stl_ascii("sliced_cube_section"));

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -1,4 +1,4 @@
-use crate::float_types::{Real, EPSILON};
+use crate::float_types::{EPSILON, Real};
 use crate::polygon::Polygon;
 use crate::vertex::Vertex;
 use nalgebra::{Isometry3, Matrix4, Point3, Rotation3, Translation3, Vector3};
@@ -33,15 +33,21 @@ impl Plane {
     pub fn split_polygon<S: Clone + Send + Sync>(
         &self,
         polygon: &Polygon<S>,
-        coplanar_front: &mut Vec<Polygon<S>>,
-        coplanar_back: &mut Vec<Polygon<S>>,
-        front: &mut Vec<Polygon<S>>,
-        back: &mut Vec<Polygon<S>>,
+    ) -> (
+        Vec<Polygon<S>>,
+        Vec<Polygon<S>>,
+        Vec<Polygon<S>>,
+        Vec<Polygon<S>>,
     ) {
         const COPLANAR: i8 = 0;
         const FRONT: i8 = 1;
         const BACK: i8 = 2;
         const SPANNING: i8 = 3;
+
+        let mut coplanar_front = Vec::new();
+        let mut coplanar_back = Vec::new();
+        let mut front = Vec::new();
+        let mut back = Vec::new();
 
         // Classify each vertex
         let (types, polygon_type) = polygon
@@ -128,6 +134,8 @@ impl Plane {
                 }
             }
         }
+
+        (coplanar_front, coplanar_back, front, back)
     }
 
     /// Returns (T, T_inv), where:

--- a/src/shapes2d.rs
+++ b/src/shapes2d.rs
@@ -569,7 +569,7 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
         let key_rect = CSG::square(key_depth, key_width, metadata.clone())
             .translate(radius - key_depth, -key_width * 0.5, 0.0);
     
-        circle.difference(&key_rect)
+        circle.difference(&key_rect).unwrap()
     }
 
     /// Creates a 2D "D" shape (circle with one flat chord).
@@ -601,7 +601,7 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
             .translate(0.0, -flat_dist, 0.0);        // now top edge is at y = -flat_dist
     
         // 3. Subtract to produce the flat chord
-        circle.difference(&rect_cutter)
+        circle.difference(&rect_cutter).unwrap()
     }
 
     /// Circle with two parallel flat chords on opposing sides (e.g., "double D" shape).
@@ -630,8 +630,8 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
             .translate(-radius, -cutter_height - flat_dist, 0.0);
     
         // 4. Subtract both
-        let with_top_flat = circle.difference(&top_rect);
-        let with_both_flats = with_top_flat.difference(&bottom_rect);
+        let with_top_flat = circle.difference(&top_rect).unwrap();
+        let with_both_flats = with_top_flat.difference(&bottom_rect).unwrap();
     
         with_both_flats
     }

--- a/src/shapes3d.rs
+++ b/src/shapes3d.rs
@@ -414,7 +414,7 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
         let rect_cutter = CSG::square(cutter_height, cutter_height, metadata.clone())
             .translate(-cutter_height, -cutter_height/2.0, 0.0);
     
-        let half_egg = egg_2d.difference(&rect_cutter);
+        let half_egg = egg_2d.difference(&rect_cutter).unwrap();
         
         half_egg.rotate_extrude(360.0, revolve_segments).convex_hull()
     }
@@ -443,7 +443,7 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
         let rect_cutter = CSG::square(cutter_height, cutter_height, metadata.clone())
             .translate(-cutter_height, -cutter_height/2.0, 0.0);
     
-        let half_teardrop = td_2d.difference(&rect_cutter);
+        let half_teardrop = td_2d.difference(&rect_cutter).unwrap();
 
         // revolve 360 degrees
         half_teardrop.rotate_extrude(360.0, revolve_segments).convex_hull()
@@ -548,7 +548,7 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
         );
     
         // Combine the shaft and head.
-        let mut canonical_arrow = shaft.union(&head);
+        let mut canonical_arrow = shaft.union(&head).unwrap();
     
         // If the arrow should point toward start, mirror the geometry in canonical space.
         // The mirror transform about the plane z = arrow_length/2 maps any point (0,0,z) to (0,0, arrow_length - z).
@@ -845,7 +845,7 @@ impl<S: Clone + Debug> CSG<S> where S: Clone + Send + Sync {
         let gyroid_surf = CSG::from_polygons(&surf_polygons);
 
         // Intersect with `self` to keep only the portion of the gyroid inside this volume.
-        let clipped = gyroid_surf.intersection(self);
+        let clipped = gyroid_surf.intersection(self).unwrap();
 
         clipped
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -380,7 +380,7 @@ fn test_node_new_and_build() {
         ],
         None,
     );
-    let node: Node<()> = Node::new(&[p.clone()]);
+    let node: Node<()> = Node::new(&[p.clone()]).unwrap();
     // The node should have built a tree with plane = p.plane, polygons = [p], no front/back children
     assert!(node.plane.is_some());
     assert_eq!(node.polygons.len(), 1);
@@ -398,7 +398,7 @@ fn test_node_invert() {
         ],
         None,
     );
-    let mut node: Node<()> = Node::new(&[p.clone()]);
+    let mut node: Node<()> = Node::new(&[p.clone()]).unwrap();
     let original_count = node.polygons.len();
     let original_normal = node.plane.as_ref().unwrap().normal;
     node.invert();
@@ -458,7 +458,7 @@ fn test_node_clip_polygons2() {
         poly_in_plane.clone(),
         poly_above.clone(),
         poly_below.clone(),
-    ]);
+    ]).unwrap();
     // Now node has polygons: [poly_in_plane], front child with poly_above, back child with poly_below
 
     // Clip a polygon that crosses from z=-0.5 to z=0.5
@@ -488,7 +488,7 @@ fn test_node_clip_to() {
         ],
         None,
     );
-    let mut node_a: Node<()> = Node::new(&[poly]);
+    let mut node_a: Node<()> = Node::new(&[poly]).unwrap();
     // Another polygon that fully encloses the above
     let big_poly: Polygon<()> = Polygon::new(
         vec![
@@ -499,7 +499,7 @@ fn test_node_clip_to() {
         ],
         None,
     );
-    let node_b: Node<()> = Node::new(&[big_poly]);
+    let node_b: Node<()> = Node::new(&[big_poly]).unwrap();
     node_a.clip_to(&node_b);
     // We expect nodeA's polygon to be present
     let all_a = node_a.all_polygons();
@@ -526,7 +526,7 @@ fn test_node_all_polygons() {
         None,
     );
 
-    let node: Node<()> = Node::new(&[poly1.clone(), poly2.clone()]);
+    let node: Node<()> = Node::new(&[poly1.clone(), poly2.clone()]).unwrap();
     let all_polys = node.all_polygons();
     // We expect to retrieve both polygons
     assert_eq!(all_polys.len(), 2);
@@ -1584,7 +1584,7 @@ fn test_slice_cylinder() {
     let cross_section = cyl.slice(Plane {
         normal: Vector3::z(),
         w: 0.0,
-    });
+    }).unwrap();
 
     // For a simple cylinder, the cross-section is typically 1 circle polygon
     // (unless the top or bottom also exactly intersect z=0, which they do not in this scenario).


### PR DESCRIPTION
Thank you for developing such a wonderful crate!

This pull request improves error handling in the `Node::build` method by using the `anyhow` crate. 
A specific edge case can cause an infinite recursion and eventually a stack overflow crash: when the first element of polygons is used to extract the plane, but the result of the split places all polygons on the same side (front or back), the recursive build enters an infinite loop.

To address this, I’ve modified the implementation so that such cases return an error using `anyhow::Result`, allowing the error to propagate to the caller rather than causing a crash.

As part of this change, the return types of boolean operations have been updated to use `anyhow::Result`. Currently, modules like shapes2d and shapes3d, which use boolean operations internally, simply unwrap the result. It might be worth considering whether these modules should also propagate anyhow::Result instead of unwrapping.