### PR TITLE
fix: warning use of deprecated function

### DIFF
--- a/src/truetype.rs
+++ b/src/truetype.rs
@@ -31,7 +31,7 @@ where S: Clone + Send + Sync {
     /// all positioned in the XY plane at z=0.
     pub fn text(text: &str, font_data: &[u8], scale: Real, metadata: Option<S>) -> Self {
         // 1) Parse the TTF font
-        let face = match ttf_parser::Face::from_slice(font_data, 0) {
+        let face = match ttf_parser::Face::parse(font_data, 0) {
             Ok(f) => f,
             Err(_) => {
                 // If the font fails to parse, return an empty 2D CSG


### PR DESCRIPTION
On building my rerf-cubes repo the warning below which I was able to duplicate the warning on csgrs main.rs by enabling `trutype-text`
```
wink@fwlaptop 25-04-26T16:15:00.904Z:~/data/prgs/3dprinting/csgrs (fix-ttf_parser-face-from_slice)
$ cargo build --features truetype-text
   Compiling csgrs v0.17.0 (/home/wink/data/prgs/3dprinting/csgrs)
warning: use of deprecated associated function `ttf_parser::Face::<'a>::from_slice`: use `parse` instead
  --> src/truetype.rs:34:44
   |
34 |         let face = match ttf_parser::Face::from_slice(font_data, 0) {
   |                                            ^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `csgrs` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.96s
wink@fwlaptop 25-04-26T16:17:35.493Z:~/data/prgs/3dprinting/csgrs (fix-ttf_parser-face-from_slice)
```

With this change there is no warning
```
wink@fwlaptop 25-04-26T16:17:35.493Z:~/data/prgs/3dprinting/csgrs (fix-ttf_parser-face-from_slice)
$ cargo build --features truetype-text
   Compiling csgrs v0.17.0 (/home/wink/data/prgs/3dprinting/csgrs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.13s
wink@fwlaptop 25-04-26T16:20:35.098Z:~/data/prgs/3dprinting/csgrs (fix-ttf_parser-face-from_slice)
```