### PR TITLE
Split `to_trimesh` and add `contains_vertex`

### DIFF
--- a/src/csg.rs
+++ b/src/csg.rs
@@ -750,7 +750,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     /// cube.subdivide_triangles(2.try_into().expect("not zero"));
     /// assert_eq!(cube.polygons.len(), 6 * 8 * 2);
     /// ```
-    pub fn subdivide_triangles(&mut self, levels: core::num::NonZeroU32) {
+    pub fn subdivide_triangles_mut(&mut self, levels: core::num::NonZeroU32) {
         // clear before error check for consistency
         self.geometry.0.clear();
 
@@ -790,7 +790,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
 
     /// Subdivide all polygons in this CSG 'levels' times, returning a new CSG.
     /// This results in a triangular mesh with more detail.
-    pub fn subdivided_triangles(&self, levels: core::num::NonZeroU32) -> CSG<S> {
+    pub fn subdivide_triangles(&self, levels: core::num::NonZeroU32) -> CSG<S> {
         #[cfg(feature = "parallel")]
         let new_polygons: Vec<Polygon<S>> = self
             .polygons

--- a/src/csg.rs
+++ b/src/csg.rs
@@ -751,9 +751,6 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     /// assert_eq!(cube.polygons.len(), 6 * 8 * 2);
     /// ```
     pub fn subdivide_triangles_mut(&mut self, levels: core::num::NonZeroU32) {
-        // clear before error check for consistency
-        self.geometry.0.clear();
-
         #[cfg(feature = "parallel")]
         {
         self.polygons = self.polygons

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
     let _ = fs::write("stl/circle_revolve_180.stl", partial_revolve.to_stl_binary("circle_revolve_180").unwrap());
 
     // 9) Subdivide triangles (for smoother sphere or shapes):
-    let subdiv_sphere = sphere.subdivide_triangles(2); // 2 subdivision levels
+    let subdiv_sphere = sphere.subdivided_triangles(2.try_into().expect("not 0")); // 2 subdivision levels
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/sphere_subdiv2.stl", subdiv_sphere.to_stl_binary("sphere_subdiv2").unwrap());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
     let _ = fs::write("stl/circle_revolve_180.stl", partial_revolve.to_stl_binary("circle_revolve_180").unwrap());
 
     // 9) Subdivide triangles (for smoother sphere or shapes):
-    let subdiv_sphere = sphere.subdivided_triangles(2.try_into().expect("not 0")); // 2 subdivision levels
+    let subdiv_sphere = sphere.subdivide_triangles(2.try_into().expect("not 0")); // 2 subdivision levels
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/sphere_subdiv2.stl", subdiv_sphere.to_stl_binary("sphere_subdiv2").unwrap());
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -141,7 +141,7 @@ where S: Clone + Send + Sync {
 
     /// Subdivide this polygon into smaller triangles.
     /// Returns a list of new triangles (each is a [Vertex; 3]).
-    pub fn subdivide_triangles(&self, subdivisions: u32) -> Vec<[Vertex; 3]> {
+    pub fn subdivide_triangles(&self, subdivisions: core::num::NonZeroU32) -> Vec<[Vertex; 3]> {
         // 1) Triangulate the polygon as it is.
         let base_tris = self.tessellate();
 
@@ -150,7 +150,7 @@ where S: Clone + Send + Sync {
         for tri in base_tris {
             // We'll keep a queue of triangles to process
             let mut queue = vec![tri];
-            for _ in 0..subdivisions {
+            for _ in 0..subdivisions.get() {
                 let mut next_level = Vec::new();
                 for t in queue {
                     let subs = subdivide_triangle(t);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -325,12 +325,12 @@ fn test_polygon_subdivide_triangles() {
         ],
         None,
     );
-    let subs = poly.subdivide_triangles(1);
+    let subs = poly.subdivide_triangles(1.try_into().expect("not 0"));
     // One triangle subdivided once => 4 smaller triangles
     assert_eq!(subs.len(), 4);
 
     // If we subdivide the same single tri 2 levels, we expect 16 sub-triangles.
-    let subs2 = poly.subdivide_triangles(2);
+    let subs2 = poly.subdivide_triangles(2.try_into().expect("not 0"));
     assert_eq!(subs2.len(), 16);
 }
 
@@ -800,7 +800,7 @@ fn test_csg_subdivide_triangles() {
     let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
     // subdivide_triangles(1) => each polygon (quad) is triangulated => 2 triangles => each tri subdivides => 4
     // So each face with 4 vertices => 2 triangles => each becomes 4 => total 8 per face => 6 faces => 48
-    let subdiv = cube.subdivide_triangles(1);
+    let subdiv = cube.subdivided_triangles(1.try_into().expect("not 0"));
     assert_eq!(subdiv.polygons.len(), 6 * 8);
 }
 
@@ -951,7 +951,7 @@ fn test_csg_to_trimesh() {
     let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
     let shape = cube.to_trimesh();
     // Should be a TriMesh with 12 triangles
-    if let Some(trimesh) = shape.as_trimesh() {
+    if let Some(trimesh) = shape {
         assert_eq!(trimesh.indices().len(), 12); // 6 faces => 2 triangles each => 12
     } else {
         panic!("Expected a TriMesh");
@@ -1229,7 +1229,7 @@ fn test_subdivide_metadata() {
         Some("LargeQuad".to_string()),
     );
     let csg = CSG::from_polygons(&[poly]);
-    let subdivided = csg.subdivide_triangles(1); // one level of subdivision
+    let subdivided = csg.subdivided_triangles(1.try_into().expect("not 0")); // one level of subdivision
 
     // Now it's split into multiple triangles. Each should keep "LargeQuad" as metadata.
     assert!(subdivided.polygons.len() > 1);
@@ -1772,4 +1772,55 @@ fn test_flatten_and_union_debug() {
         flattened.polygons[0].vertices.len() >= 3,
         "Should form at least a triangle"
     );
+}
+
+#[test]
+fn test_contains_vertex() {
+    let csg_cube = CSG::<()>::cube(6.0, 6.0, 6.0, None);
+
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 3.0)));
+    assert!(csg_cube.contains_vertex(&Point3::new(1.0, 2.0, 5.9)));
+    assert!(!csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 6.0)));
+    assert!(!csg_cube.contains_vertex(&Point3::new(3.0, 3.0, -6.0)));
+    assert!(!csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 0.0)));
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 0.01)));
+
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 5.99999999999)));
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 6.0 - 1e-11)));
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 6.0 - 1e-14)));
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 5.9 + 9e-9)));
+
+    assert!(csg_cube.contains_vertex(&Point3::new(3.0, -3.0, 3.0)));
+    assert!(!csg_cube.contains_vertex(&Point3::new(3.0, -3.01, 3.0)));
+    assert!(csg_cube.contains_vertex(&Point3::new(0.01, 4.0, 3.0)));
+    assert!(!csg_cube.contains_vertex(&Point3::new(-0.01, 4.0, 3.0)));
+
+    let csg_cube_hole = CSG::<()>::cube(4.0, 4.0, 4.0, None);
+    let cube_with_hole = csg_cube.difference(&csg_cube_hole);
+
+    assert!(!cube_with_hole.contains_vertex(&Point3::new(0.01, 4.0, 3.0)));
+    assert!(cube_with_hole.contains_vertex(&Point3::new(0.01, 4.01, 3.0)));
+
+    assert!(!cube_with_hole.contains_vertex(&Point3::new(-0.01, 4.0, 3.0)));
+    assert!(cube_with_hole.contains_vertex(&Point3::new(1.0, 2.0, 5.9)));
+    assert!(!cube_with_hole.contains_vertex(&Point3::new(3.0, 3.0, 6.0)));
+
+    let csg_sphere = CSG::<()>::sphere(6.0, 14, 14, None);
+
+    assert!(csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, 3.0)));
+    assert!(csg_sphere.contains_vertex(&Point3::new(-3.0, -3.0, -3.0)));
+    assert!(!csg_sphere.contains_vertex(&Point3::new(1.0, 2.0, 5.9)));
+
+    assert!(!csg_sphere.contains_vertex(&Point3::new(1.0, 1.0, 5.8)));
+    assert!(!csg_sphere.contains_vertex(&Point3::new(0.0, 3.0, 5.8)));
+    assert!(csg_sphere.contains_vertex(&Point3::new(0.0, 0.0, 5.8)));
+
+    assert!(!csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, 6.0)));
+    assert!(!csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, -6.0)));
+    assert!(csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, 0.0)));
+
+    assert!(csg_sphere.contains_vertex(&Point3::new(0.0, 0.0, -5.8)));
+    assert!(!csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, -5.8)));
+    assert!(!csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, -6.01)));
+    assert!(csg_sphere.contains_vertex(&Point3::new(3.0, 3.0, 0.01)));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -800,7 +800,7 @@ fn test_csg_subdivide_triangles() {
     let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
     // subdivide_triangles(1) => each polygon (quad) is triangulated => 2 triangles => each tri subdivides => 4
     // So each face with 4 vertices => 2 triangles => each becomes 4 => total 8 per face => 6 faces => 48
-    let subdiv = cube.subdivided_triangles(1.try_into().expect("not 0"));
+    let subdiv = cube.subdivide_triangles(1.try_into().expect("not 0"));
     assert_eq!(subdiv.polygons.len(), 6 * 8);
 }
 
@@ -1229,7 +1229,7 @@ fn test_subdivide_metadata() {
         Some("LargeQuad".to_string()),
     );
     let csg = CSG::from_polygons(&[poly]);
-    let subdivided = csg.subdivided_triangles(1.try_into().expect("not 0")); // one level of subdivision
+    let subdivided = csg.subdivide_triangles(1.try_into().expect("not 0")); // one level of subdivision
 
     // Now it's split into multiple triangles. Each should keep "LargeQuad" as metadata.
     assert!(subdivided.polygons.len() > 1);


### PR DESCRIPTION
Split `to_trimesh` into `to_rapier_shape` and `to_trimesh` as well as add `contains_vertex`.
The code has some unwraps witch will be resolved in the next PR adding error handling to the whole codebase.