### PR TITLE
for a square we must have width=length, for a cube width=length=height.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ cargo add csgrs
 type CSG = csgrs::csg::CSG<()>;
 
 // Create two shapes:
-let cube = CSG::cube(2.0, 2.0, 2.0, None);  // 2×2×2 cube at origin, no metadata
+let cube = CSG::cube(2.0, None);  // 2×2×2 cube at origin, no metadata
 let sphere = CSG::sphere(1.0, 16, 8, None); // sphere of radius=1 at origin, no metadata
 
 // Difference one from the other:
@@ -83,7 +83,8 @@ or when a Geometry is converted into polygons using `CSG::to_polygons(...)`.
 
 ### 2D Shapes
 
-- <img src="docs/square.png" width="128" alt="top down view of a square"/> **`CSG::square(width: Real, length: Real, metadata: Option<S>)`**
+- <img src="docs/square.png" width="128" alt="top down view of a square"/> **`CSG::square(width: Real, metadata: Option<S>)`**
+- **`CSG::rectangle(width: Real, length: Real, metadata: Option<S>)`**
 - <img src="docs/circle.png" width="128" alt="top down view of a circle"/> **`CSG::circle(radius: Real, segments: usize, metadata: Option<S>)`**
 - <img src="docs/polygon.png" width="128" alt="top down view of a triangle"/> **`CSG::polygon(&[[x1,y1],[x2,y2],...], metadata: Option<S>)`**
 - <img src="docs/rounded_rectangle.png" width="128" alt="top down view of a rectangle with rounded corners"/> **`CSG::rounded_rectangle(width: Real, height: Real, corner_radius: Real, corner_segments: usize, metadata: Option<S>)`**
@@ -117,8 +118,8 @@ or when a Geometry is converted into polygons using `CSG::to_polygons(...)`.
 - **`CSG::cycloidal_rack_2d(module_: Real, num_teeth: usize, generating_radius: Real, clearance: Real, segments_per_flank: usize, metadata: Option<S>)`** - under construction
 
 ```rust
-let square = CSG::square(1.0, 1.0, None); // 1×1 at origin
-let rect = CSG::square(2.0, 4.0, None);
+let square = CSG::square(1.0, None); // 1×1 at origin
+let rect = CSG::rectangle(2.0, 4.0, None);
 let circle = CSG::circle(1.0, 32, None); // radius=1, 32 segments
 let circle2 = CSG::circle(2.0, 64, None);
 
@@ -139,7 +140,7 @@ Extrusions build 3D polygons from 2D Geometries.
 - <img src="docs/rotate_extrude.png" width="128"  alt="an arch with round ends"/> **`CSG::rotate_extrude(angle_degs, segments)`** - Extrude while rotating around the Y axis
 
 ```rust
-let square = CSG::square(2.0, 2.0, None);
+let square = CSG::square(2.0, None);
 let prism = square.extrude(5.0);
 
 let revolve_shape = square.rotate_extrude(360.0, 16);
@@ -179,7 +180,7 @@ If either radius is within EPSILON of 0.0, a cone terminating at a point is cons
 
 ```rust
 // Unit cube at origin, no metadata
-let cube = CSG::cube(1.0, 1.0, 1.0, None);
+let cube = CSG::cube(1.0, None);
 
 // Sphere of radius=2 at origin with 32 segments and 16 stacks
 let sphere = CSG::sphere(2.0, 32, 16, None);

--- a/src/csg.rs
+++ b/src/csg.rs
@@ -621,7 +621,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     ///
     /// # Example
     /// ```
-    /// let csg = CSG::cube(1.0, 1.0, 3.0, None).translate(2.0, 1.0, -2.0);
+    /// let csg = CSG::cuboid(1.0, 1.0, 3.0, None).translate(2.0, 1.0, -2.0);
     /// let floated = csg.float();
     /// assert_eq!(floated.bounding_box().mins.z, 0.0);
     /// ```
@@ -810,13 +810,13 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     ///
     /// ## Example
     /// ```
-    /// let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    /// let cube: CSG<()> = CSG::cube(2.0, None);
     /// // subdivide_triangles(1) => each polygon (quad) is triangulated => 2 triangles => each tri subdivides => 4
     /// // So each face with 4 vertices => 2 triangles => each becomes 4 => total 8 per face => 6 faces => 48
     /// cube.subdivide_triangles(1.try_into().expect("not zero"));
     /// assert_eq!(cube.polygons.len(), 6 * 8);
     ///
-    /// let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    /// let cube: CSG<()> = CSG::cube(2.0, None);
     /// cube.subdivide_triangles(2.try_into().expect("not zero"));
     /// assert_eq!(cube.polygons.len(), 6 * 8 * 2);
     /// ```
@@ -1104,7 +1104,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     /// # use csgrs::CSG;
     /// # use nalgebra::Point3;
     /// # use nalgebra::Vector3;
-    /// let csg_cube = CSG::<()>::cube(6.0, 6.0, 6.0, None);
+    /// let csg_cube = CSG::<()>::cube(6.0, None);
     ///
     /// assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 3.0)).unwrap());
     /// assert!(csg_cube.contains_vertex(&Point3::new(1.0, 2.0, 5.9)).unwrap());

--- a/src/extrudes.rs
+++ b/src/extrudes.rs
@@ -284,7 +284,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     ///
     /// # Example
     /// ```
-    /// let shape_2d = CSG::square(2.0, 2.0, None); // a 2D square in XY
+    /// let shape_2d = CSG::square(2.0, None); // a 2D square in XY
     /// let extruded = shape_2d.linear_extrude(
     ///     direction = Vector3::new(0.0, 0.0, 10.0),
     ///     twist = 360.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let _ = fs::create_dir_all("stl");
 
     // 1) Basic shapes: cube, sphere, cylinder
-    let cube = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube = CSG::cube(2.0, None);
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/cube.stl", cube.to_stl_binary("cube").unwrap());
 
@@ -101,7 +101,7 @@ fn main() {
     );
 
     // 7) 2D shapes and 2D offsetting
-    let square_2d = CSG::square(2.0, 2.0, None); // 2x2 square, centered
+    let square_2d = CSG::square(2.0, None); // 2x2 square, centered
     let _ = fs::write("stl/square_2d.stl", square_2d.to_stl_ascii("square_2d"));
 
     let circle_2d = CSG::circle(1.0, 32, None);
@@ -230,7 +230,7 @@ fn main() {
 
     // 1) Create a cube from (-1,-1,-1) to (+1,+1,+1)
     //    (By default, CSG::cube(None) is from -1..+1 if the "radius" is [1,1,1].)
-    let cube = CSG::cube(100.0, 100.0, 100.0, None);
+    let cube = CSG::cube(100.0, None);
     // 2) Flatten into the XY plane
     let flattened = cube.flatten();
     let _ = fs::write(
@@ -276,7 +276,7 @@ fn main() {
     //let _ = fs::write("stl/retriangulated.stl", retriangulated_shape.to_stl_binary("retriangulated").unwrap());
 
     let sphere_test = CSG::sphere(1.0, 16, 8, None);
-    let cube_test = CSG::cube(1.0, 1.0, 1.0, None);
+    let cube_test = CSG::cube(1.0, None);
     let res = cube_test.difference(&sphere_test);
     #[cfg(feature = "stl-io")]
     let _ = fs::write(
@@ -696,7 +696,7 @@ fn main() {
 
     // Scene L: Demonstrate rotate_extrude (360 deg) on a square
     {
-        let small_square = CSG::square(1.0, 1.0, None).translate(2.0, 0.0, 0.0);
+        let small_square = CSG::square(1.0, None).translate(2.0, 0.0, 0.0);
         let revolve = small_square.rotate_extrude(360.0, 24);
         let _ = fs::write(
             "stl/scene_square_revolve_360.stl",
@@ -707,7 +707,7 @@ fn main() {
     // Scene M: Demonstrate “mirror” across a Y=0 plane
     {
         let plane_y = Plane::from_normal(Vector3::y(), 0.0);
-        let shape = CSG::square(2.0, 1.0, None)
+        let shape = CSG::rectangle(2.0, 1.0, None)
             .translate(1.0, 1.0, 0.0)
             .extrude(0.1);
         let mirrored = shape.mirror(plane_y);
@@ -735,7 +735,7 @@ fn main() {
         let scale_mat = Matrix4::new_scaling(0.5);
         // Combine
         let transform_mat = xlate * scale_mat;
-        let shape = CSG::cube(1.0, 1.0, 1.0, None).transform(&transform_mat);
+        let shape = CSG::cube(1.0, None).transform(&transform_mat);
         let _ = fs::write(
             "stl/scene_transform_cube.stl",
             shape.to_stl_ascii("scene_transform_cube"),

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,7 +1,7 @@
 use crate::csg::CSG;
 use crate::float_types::Real;
 use geo::{Geometry, GeometryCollection};
-use geo_buf::{buffer_multi_polygon, buffer_polygon};
+use geo_buf::{buffer_multi_polygon, buffer_polygon,buffer_polygon_rounded, buffer_multi_polygon_rounded};
 use std::fmt::Debug;
 use std::sync::OnceLock;
 

--- a/src/shapes2d.rs
+++ b/src/shapes2d.rs
@@ -8,17 +8,17 @@ use std::fmt::Debug;
 use std::sync::OnceLock;
 
 impl<S: Clone + Debug + Send + Sync> CSG<S> {
-    /// Creates a 2D square in the XY plane.
+    /// Creates a 2D rectangle in the XY plane.
     ///
     /// # Parameters
     ///
-    /// - `width`: the width of the square
-    /// - `length`: the height of the square
+    /// - `width`: the width of the rectangle
+    /// - `length`: the height of the rectangle
     /// - `metadata`: optional metadata
     ///
     /// # Example
-    /// let sq2 = CSG::square(2.0, 3.0, None);
-    pub fn square(width: Real, length: Real, metadata: Option<S>) -> Self {
+    /// let rect = CSG::rectangle(2.0, 3.0, None);
+    pub fn rectangle(width: Real, length: Real, metadata: Option<S>) -> Self {
         // In geo, a Polygon is basically (outer: LineString, Vec<LineString> for holes).
         let outer = line_string![
             (x: 0.0,     y: 0.0),
@@ -34,6 +34,20 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
             metadata,
         )
     }
+
+    /// Creates a 2D square in the XY plane.
+    ///
+    /// # Parameters
+    ///
+    /// - `width`: the width=length of the square
+    /// - `metadata`: optional metadata
+    ///
+    /// # Example
+    /// let sq2 = CSG::square(2.0, None);
+    pub fn square(width: Real, metadata: Option<S>) -> Self {
+        Self::rectangle(width,width,metadata)
+    }
+
 
     /// Creates a 2D circle in the XY plane.
     pub fn circle(radius: Real, segments: usize, metadata: Option<S>) -> Self {
@@ -105,7 +119,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
     ) -> Self {
         let r = corner_radius.min(width * 0.5).min(height * 0.5);
         if r <= EPSILON {
-            return Self::square(width, height, metadata);
+            return Self::rectangle(width, height, metadata);
         }
         let mut coords = Vec::new();
         // We'll approximate each 90° corner with `corner_segments` arcs
@@ -622,7 +636,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
         //    - its right edge at x = +radius
         //    - so it spans from x = (radius - key_depth) to x = radius
         //    - and from y = -key_width/2 to y = +key_width/2
-        let key_rect = CSG::square(key_depth, key_width, metadata.clone()).translate(
+        let key_rect = CSG::rectangle(key_depth, key_width, metadata.clone()).translate(
             radius - key_depth,
             -key_width * 0.5,
             0.0,
@@ -655,7 +669,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
         //    Height = large enough, we just shift it so top edge is at y = -flat_dist.
         //    So that rectangle covers from y = -∞ up to y = -flat_dist.
         let cutter_height = 9999.0; // some large number
-        let rect_cutter = CSG::square(2.0 * radius, cutter_height, metadata.clone())
+        let rect_cutter = CSG::rectangle(2.0 * radius, cutter_height, metadata.clone())
             .translate(-radius, -cutter_height, 0.0) // put its bottom near "negative infinity"
             .translate(0.0, -flat_dist, 0.0); // now top edge is at y = -flat_dist
 
@@ -679,12 +693,12 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
 
         // 2. Large rectangle to cut the TOP (above +flat_dist)
         let cutter_height = 9999.0;
-        let top_rect = CSG::square(2.0 * radius, cutter_height, metadata.clone())
+        let top_rect = CSG::rectangle(2.0 * radius, cutter_height, metadata.clone())
             // place bottom at y=flat_dist
             .translate(-radius, flat_dist, 0.0);
 
         // 3. Large rectangle to cut the BOTTOM (below -flat_dist)
-        let bottom_rect = CSG::square(2.0 * radius, cutter_height, metadata.clone())
+        let bottom_rect = CSG::rectangle(2.0 * radius, cutter_height, metadata.clone())
             // place top at y=-flat_dist => bottom extends downward
             .translate(-radius, -cutter_height - flat_dist, 0.0);
 

--- a/src/shapes3d.rs
+++ b/src/shapes3d.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 impl<S: Clone + Debug + Send + Sync> CSG<S> {
     /// Create a right prism (a box) that spans from (0, 0, 0)
     /// to (width, length, height). All dimensions must be >= 0.
-    pub fn cube(width: Real, length: Real, height: Real, metadata: Option<S>) -> CSG<S> {
+    pub fn cuboid(width: Real, length: Real, height: Real, metadata: Option<S>) -> CSG<S> {
         // Define the eight corner points of the prism.
         //    (x, y, z)
         let p000 = Point3::new(0.0, 0.0, 0.0);
@@ -104,6 +104,10 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
 
         // Combine all faces into a CSG
         CSG::from_polygons(&[bottom, top, front, back, left, right])
+    }
+
+    pub fn cube(width: Real, metadata: Option<S>) -> CSG<S> {
+        Self::cuboid(width, width, width, metadata)
     }
 
     /// Construct a sphere with radius, segments, stacks
@@ -432,7 +436,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
 
         // Build a large rectangle that cuts off everything
         let cutter_height = 9999.0; // some large number
-        let rect_cutter = CSG::square(cutter_height, cutter_height, metadata.clone())
+        let rect_cutter = CSG::square(cutter_height, metadata.clone())
             .translate(-cutter_height, -cutter_height / 2.0, 0.0);
 
         let half_egg = egg_2d.difference(&rect_cutter);
@@ -461,7 +465,7 @@ impl<S: Clone + Debug + Send + Sync> CSG<S> {
 
         // Build a large rectangle that cuts off everything
         let cutter_height = 9999.0; // some large number
-        let rect_cutter = CSG::square(cutter_height, cutter_height, metadata.clone())
+        let rect_cutter = CSG::square(cutter_height, metadata.clone())
             .translate(-cutter_height, -cutter_height / 2.0, 0.0);
 
         let half_teardrop = td_2d.difference(&rect_cutter);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,7 +91,7 @@ fn test_polygon_construction() {
 
 #[test]
 fn test_to_stl_ascii() {
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
     let stl_str = cube.to_stl_ascii("test_cube");
     // Basic checks
     assert!(stl_str.contains("solid test_cube"));
@@ -525,8 +525,8 @@ fn test_csg_from_polygons_and_to_polygons() {
 
 #[test]
 fn test_csg_union() {
-    let cube1: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None).translate(-1.0, -1.0, -1.0); // from -1 to +1 in all coords
-    let cube2: CSG<()> = CSG::cube(1.0, 1.0, 1.0, None).translate(0.5, 0.5, 0.5);
+    let cube1: CSG<()> = CSG::cube(2.0, None).translate(-1.0, -1.0, -1.0); // from -1 to +1 in all coords
+    let cube2: CSG<()> = CSG::cube(1.0, None).translate(0.5, 0.5, 0.5);
 
     let union_csg = cube1.union(&cube2);
     let polys = union_csg.to_polygons();
@@ -548,8 +548,8 @@ fn test_csg_union() {
 #[test]
 fn test_csg_difference() {
     // Subtract a smaller cube from a bigger one
-    let big_cube: CSG<()> = CSG::cube(4.0, 4.0, 4.0, None).translate(-2.0, -2.0, -2.0); // radius=2 => spans [-2,2]
-    let small_cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None).translate(-1.0, -1.0, -1.0); // radius=1 => spans [-1,1]
+    let big_cube: CSG<()> = CSG::cube(4.0, None).translate(-2.0, -2.0, -2.0); // radius=2 => spans [-2,2]
+    let small_cube: CSG<()> = CSG::cube(2.0, None).translate(-1.0, -1.0, -1.0); // radius=1 => spans [-1,1]
 
     let result = big_cube.difference(&small_cube);
     let polys = result.to_polygons();
@@ -567,7 +567,7 @@ fn test_csg_difference() {
 
 #[test]
 fn test_csg_union2() {
-    let c1: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None); // cube from (-1..+1) if that's how you set radius=1 by default
+    let c1: CSG<()> = CSG::cube(2.0, None); // cube from (-1..+1) if that's how you set radius=1 by default
     let c2: CSG<()> = CSG::sphere(1.0, 16, 8, None); // default sphere radius=1
     let unioned = c1.union(&c2);
     // We can check bounding box is bigger or at least not smaller than either shape’s box
@@ -580,7 +580,7 @@ fn test_csg_union2() {
 
 #[test]
 fn test_csg_intersect() {
-    let c1: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let c1: CSG<()> = CSG::cube(2.0, None);
     let c2: CSG<()> = CSG::sphere(1.0, 16, 8, None);
     let isect = c1.intersection(&c2);
     let bb_isect = isect.bounding_box();
@@ -596,7 +596,7 @@ fn test_csg_intersect() {
 #[test]
 fn test_csg_intersect2() {
     let sphere: CSG<()> = CSG::sphere(1.0, 16, 8, None);
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
 
     let intersection = sphere.intersection(&cube);
     let polys = intersection.to_polygons();
@@ -618,7 +618,7 @@ fn test_csg_intersect2() {
 
 #[test]
 fn test_csg_inverse() {
-    let c1: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let c1: CSG<()> = CSG::cube(2.0, None);
     let inv = c1.inverse();
     // The polygons are flipped
     // We can check just that the polygon planes are reversed, etc.
@@ -649,7 +649,7 @@ fn test_csg_inverse() {
 
 #[test]
 fn test_csg_cube() {
-    let c: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let c: CSG<()> = CSG::cube(2.0, None);
     // By default, corner at (0,0,0)
     // We expect 6 faces, each 4 vertices = 6 polygons
     assert_eq!(c.polygons.len(), 6);
@@ -721,7 +721,7 @@ fn test_csg_polyhedron() {
 
 #[test]
 fn test_csg_transform_translate_rotate_scale() {
-    let c: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None).center();
+    let c: CSG<()> = CSG::cube(2.0, None).center();
     let translated = c.translate(1.0, 2.0, 3.0);
     let rotated = c.rotate(90.0, 0.0, 0.0); // 90 deg about X
     let scaled = c.scale(2.0, 1.0, 1.0);
@@ -752,7 +752,7 @@ fn test_csg_transform_translate_rotate_scale() {
 
 #[test]
 fn test_csg_mirror() {
-    let c: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let c: CSG<()> = CSG::cube(2.0, None);
     let plane_x = Plane::from_normal(Vector3::x(), 0.0); // x=0 plane
     let mirror_x = c.mirror(plane_x);
     let bb_mx = mirror_x.bounding_box();
@@ -774,8 +774,8 @@ fn test_csg_convex_hull() {
 #[test]
 fn test_csg_minkowski_sum() {
     // Minkowski sum of two cubes => bigger cube offset by edges
-    let c1: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None).center();
-    let c2: CSG<()> = CSG::cube(1.0, 1.0, 1.0, None).center();
+    let c1: CSG<()> = CSG::cube(2.0, None).center();
+    let c2: CSG<()> = CSG::cube(1.0, None).center();
     let sum = c1.minkowski_sum(&c2);
     let bb_sum = sum.bounding_box();
     // Expect bounding box from -1.5..+1.5 in each axis if both cubes were centered at (0,0,0).
@@ -785,7 +785,7 @@ fn test_csg_minkowski_sum() {
 
 #[test]
 fn test_csg_subdivide_triangles() {
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
     // subdivide_triangles(1) => each polygon (quad) is triangulated => 2 triangles => each tri subdivides => 4
     // So each face with 4 vertices => 2 triangles => each becomes 4 => total 8 per face => 6 faces => 48
     let subdiv = cube.subdivide_triangles(1.try_into().expect("not 0"));
@@ -794,7 +794,7 @@ fn test_csg_subdivide_triangles() {
 
 #[test]
 fn test_csg_renormalize() {
-    let mut cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let mut cube: CSG<()> = CSG::cube(2.0, None);
     // After we do some transforms, normals might be changed. We can artificially change them:
     for poly in &mut cube.polygons {
         for v in &mut poly.vertices {
@@ -814,7 +814,7 @@ fn test_csg_renormalize() {
 
 #[test]
 fn test_csg_ray_intersections() {
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None).center();
+    let cube: CSG<()> = CSG::cube(2.0, None).center();
     // Ray from (-2,0,0) toward +X
     let origin = Point3::new(-2.0, 0.0, 0.0);
     let direction = Vector3::new(1.0, 0.0, 0.0);
@@ -828,7 +828,7 @@ fn test_csg_ray_intersections() {
 
 #[test]
 fn test_csg_square() {
-    let sq: CSG<()> = CSG::square(2.0, 2.0, None);
+    let sq: CSG<()> = CSG::square(2.0, None);
     // Single polygon, 4 vertices
     assert_eq!(sq.polygons.len(), 1);
     let poly = &sq.polygons[0];
@@ -854,7 +854,7 @@ fn test_csg_polygon_2d() {
 
 #[test]
 fn test_csg_extrude() {
-    let sq: CSG<()> = CSG::square(2.0, 2.0, None); // default 1x1 square at XY plane
+    let sq: CSG<()> = CSG::square(2.0, None); // default 1x1 square at XY plane
     let extruded = sq.extrude(5.0);
     // We expect:
     //   bottom polygon: 1
@@ -873,7 +873,7 @@ fn test_csg_rotate_extrude() {
     // Default square is from (0,0) to (1,1) in XY.
     // Shift it so it’s from (1,0) to (2,1) — i.e. at least 1.0 unit away from the Z-axis.
     // and rotate it 90 degrees so that it can be swept around Z
-    let square: CSG<()> = CSG::square(2.0, 2.0, None)
+    let square: CSG<()> = CSG::square(2.0, None)
         .translate(1.0, 0.0, 0.0)
         .rotate(90.0, 0.0, 0.0);
 
@@ -899,7 +899,7 @@ fn test_csg_bounding_box() {
 
 #[test]
 fn test_csg_vertices() {
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
     let verts = cube.vertices();
     // 6 faces x 4 vertices each = 24
     assert_eq!(verts.len(), 24);
@@ -907,7 +907,7 @@ fn test_csg_vertices() {
 
 #[test]
 fn test_csg_offset_2d() {
-    let square: CSG<()> = CSG::square(2.0, 2.0, None);
+    let square: CSG<()> = CSG::square(2.0, None);
     let grown = square.offset(0.5);
     let shrunk = square.offset(-0.5);
     let bb_square = square.bounding_box();
@@ -937,7 +937,7 @@ fn test_csg_text() {
 
 #[test]
 fn test_csg_to_trimesh() {
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
     let shape = cube.to_trimesh();
     // Should be a TriMesh with 12 triangles
     if let Some(trimesh) = shape {
@@ -949,7 +949,7 @@ fn test_csg_to_trimesh() {
 
 #[test]
 fn test_csg_mass_properties() {
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None).center(); // side=2 => volume=8. If density=1 => mass=8
+    let cube: CSG<()> = CSG::cube(2.0, None).center(); // side=2 => volume=8. If density=1 => mass=8
     let (mass, com, _frame) = cube.mass_properties(1.0);
     println!("{:#?}", mass);
     // For a centered cube with side 2, volume=8 => mass=8 => COM=(0,0,0)
@@ -962,7 +962,7 @@ fn test_csg_mass_properties() {
 #[test]
 fn test_csg_to_rigid_body() {
     use crate::float_types::rapier3d::prelude::*;
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
     let mut rb_set = RigidBodySet::new();
     let mut co_set = ColliderSet::new();
     let handle = cube.to_rigid_body(
@@ -983,7 +983,7 @@ fn test_csg_to_stl_and_from_stl_file() -> Result<(), Box<dyn std::error::Error>>
     // You can redirect to a temp file or do an in-memory test.
     let tmp_path = "test_csg_output.stl";
 
-    let cube: CSG<()> = CSG::cube(2.0, 2.0, 2.0, None);
+    let cube: CSG<()> = CSG::cube(2.0, None);
     let res = cube.to_stl_binary("A cube");
     let _ = std::fs::write(tmp_path, res.as_ref().unwrap());
     assert!(res.is_ok());
@@ -1099,14 +1099,14 @@ fn test_union_metadata() {
     // each new polygon inherits the shared data from whichever polygon it came from.
 
     // Square1 from (0,0) to (1,1) => label "Square1"
-    let sq1 = CSG::square(1.0, 1.0, None); // bottom-left at (0,0), top-right at (1,1)
+    let sq1 = CSG::square(1.0, None); // bottom-left at (0,0), top-right at (1,1)
     let mut sq1 = sq1; // now let us set shared data for each polygon
     for p in &mut sq1.polygons {
         p.set_metadata("Square1".to_string());
     }
 
     // Translate Square2 so it partially overlaps. => label "Square2"
-    let sq2 = CSG::square(1.0, 1.0, None).translate(0.5, 0.0, 0.0);
+    let sq2 = CSG::square(1.0, None).translate(0.5, 0.0, 0.0);
     let mut sq2 = sq2;
     for p in &mut sq2.polygons {
         p.set_metadata("Square2".to_string());
@@ -1134,12 +1134,12 @@ fn test_difference_metadata() {
     // come from the *minuend* (the first shape) with *some* portion clipped out.
     // So the differenced portion from the second shape won't appear in the final.
 
-    let mut cube1 = CSG::cube(2.0, 2.0, 2.0, None);
+    let mut cube1 = CSG::cube(2.0, None);
     for p in &mut cube1.polygons {
         p.set_metadata("Cube1".to_string());
     }
 
-    let mut cube2 = CSG::cube(2.0, 2.0, 2.0, None).translate(0.5, 0.5, 0.5);
+    let mut cube2 = CSG::cube(2.0, None).translate(0.5, 0.5, 0.5);
     for p in &mut cube2.polygons {
         p.set_metadata("Cube2".to_string());
     }
@@ -1161,12 +1161,12 @@ fn test_intersect_metadata() {
     // keep the "side" from whichever shape is relevant. That might be shape A or B or both.
     // We'll check that we only see "Cube1" or "Cube2" but not random data.
 
-    let mut cube1 = CSG::cube(2.0, 2.0, 2.0, None);
+    let mut cube1 = CSG::cube(2.0, None);
     for p in &mut cube1.polygons {
         p.set_metadata("Cube1".to_string());
     }
 
-    let mut cube2 = CSG::cube(2.0, 2.0, 2.0, None).translate(0.5, 0.5, 0.5);
+    let mut cube2 = CSG::cube(2.0, None).translate(0.5, 0.5, 0.5);
     for p in &mut cube2.polygons {
         p.set_metadata("Cube2".to_string());
     }
@@ -1191,7 +1191,7 @@ fn test_flip_invert_metadata() {
     // Flipping or inverting a shape should NOT change the shared data;
     // it only flips normals/polygons.
 
-    let mut csg = CSG::cube(2.0, 2.0, 2.0, None);
+    let mut csg = CSG::cube(2.0, None);
     for p in &mut csg.polygons {
         p.set_metadata("MyCube".to_string());
     }
@@ -1256,11 +1256,11 @@ fn test_complex_metadata_struct_in_boolean_ops() {
     #[derive(Debug, Clone, PartialEq)]
     struct Color(u8, u8, u8);
 
-    let mut csg1 = CSG::cube(2.0, 2.0, 2.0, None);
+    let mut csg1 = CSG::cube(2.0, None);
     for p in &mut csg1.polygons {
         p.set_metadata(Color(255, 0, 0));
     }
-    let mut csg2 = CSG::cube(2.0, 2.0, 2.0, None).translate(0.5, 0.5, 0.5);
+    let mut csg2 = CSG::cube(2.0, None).translate(0.5, 0.5, 0.5);
     for p in &mut csg2.polygons {
         p.set_metadata(Color(0, 255, 0));
     }
@@ -1291,7 +1291,7 @@ fn signed_area(polygon: &Polygon<()>) -> Real {
 
 #[test]
 fn test_square_ccw_ordering() {
-    let square = CSG::square(2.0, 2.0, None);
+    let square = CSG::square(2.0, None);
     assert_eq!(square.polygons.len(), 1);
     let poly = &square.polygons[0];
     let area = signed_area(poly);
@@ -1300,7 +1300,7 @@ fn test_square_ccw_ordering() {
 
 #[test]
 fn test_offset_2d_positive_distance_grows() {
-    let square = CSG::square(2.0, 2.0, None); // Centered square with size 2x2
+    let square = CSG::square(2.0, None); // Centered square with size 2x2
     let offset = square.offset(0.5); // Positive offset should grow the square
 
     // The original square has area 4.0
@@ -1316,7 +1316,7 @@ fn test_offset_2d_positive_distance_grows() {
 
 #[test]
 fn test_offset_2d_negative_distance_shrinks() {
-    let square = CSG::square(2.0, 2.0, None); // Centered square with size 2x2
+    let square = CSG::square(2.0, None); // Centered square with size 2x2
     let offset = square.offset(-0.5); // Negative offset should shrink the square
 
     // The original square has area 4.0
@@ -1513,7 +1513,7 @@ fn test_union_of_extruded_shapes() {
 fn test_flatten_cube() {
     // 1) Create a cube from (-1,-1,-1) to (+1,+1,+1)
     //    (By default, CSG::cube(None) is from -1..+1 if the "radius" is [1,1,1].)
-    let cube = CSG::<()>::cube(2.0, 2.0, 2.0, None);
+    let cube = CSG::<()>::cube(2.0, None);
     // 2) Flatten into the XY plane
     let flattened = cube.flatten();
 
@@ -1749,7 +1749,7 @@ fn test_flatten_and_union_collinear_edges() {
 /// you can println! debug info in `flatten_and_union`.
 #[test]
 fn test_flatten_and_union_debug() {
-    let csg_square = CSG::<()>::square(2.0, 2.0, None); // a 1×1 square at [0..1, 0..1]
+    let csg_square = CSG::<()>::square(2.0, None); // a 1×1 square at [0..1, 0..1]
     let flattened = csg_square.flatten();
     assert!(
         !flattened.polygons.is_empty(),
@@ -1763,7 +1763,7 @@ fn test_flatten_and_union_debug() {
 
 #[test]
 fn test_contains_vertex() {
-    let csg_cube = CSG::<()>::cube(6.0, 6.0, 6.0, None);
+    let csg_cube = CSG::<()>::cube(6.0, None);
 
     assert!(csg_cube.contains_vertex(&Point3::new(3.0, 3.0, 3.0)));
     assert!(csg_cube.contains_vertex(&Point3::new(1.0, 2.0, 5.9)));
@@ -1782,7 +1782,7 @@ fn test_contains_vertex() {
     assert!(csg_cube.contains_vertex(&Point3::new(0.01, 4.0, 3.0)));
     assert!(!csg_cube.contains_vertex(&Point3::new(-0.01, 4.0, 3.0)));
 
-    let csg_cube_hole = CSG::<()>::cube(4.0, 4.0, 4.0, None);
+    let csg_cube_hole = CSG::<()>::cube(4.0, None);
     let cube_with_hole = csg_cube.difference(&csg_cube_hole);
 
     assert!(!cube_with_hole.contains_vertex(&Point3::new(0.01, 4.0, 3.0)));


### PR DESCRIPTION
rename fn square to fn rectangle and define square utility fn with only width  (and metadata)
rename fn cube    to fn cuboid,     and define cube    utility fn with only width  (and metadata)

todo: add a rectangle.png image