### PR TITLE
Improve `Mesh::polyhedron`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -191,13 +191,13 @@ fn main() {
         [0.5, 1.0, 0.0],
         [0.5, 0.5, 1.0],
     ];
-    let faces = vec![
-        vec![0, 2, 1], // base triangle
-        vec![0, 1, 3], // side
-        vec![1, 2, 3],
-        vec![2, 0, 3],
+    let faces: [&[usize]; 4] = [
+        &[0, 2, 1], // base triangle
+        &[0, 1, 3], // side
+        &[1, 2, 3],
+        &[2, 0, 3],
     ];
-    let poly = Mesh::polyhedron(&points, &faces, None);
+    let poly = Mesh::polyhedron(&points, &faces, None).unwrap();
     #[cfg(feature = "stl-io")]
     let _ = fs::write("stl/tetrahedron.stl", poly.to_stl_ascii("tetrahedron"));
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -714,8 +714,8 @@ fn test_csg_polyhedron() {
         [0.0, 1.0, 0.0], // 2
         [0.0, 0.0, 1.0], // 3
     ];
-    let faces = vec![vec![0, 1, 2], vec![0, 1, 3], vec![1, 2, 3], vec![2, 0, 3]];
-    let csg_tetra: Mesh<()> = Mesh::polyhedron(pts, &faces, None);
+    let faces: [&[usize]; 4] = [&[0, 1, 2], &[0, 1, 3], &[1, 2, 3], &[2, 0, 3]];
+    let csg_tetra: Mesh<()> = Mesh::polyhedron(pts, &faces, None).unwrap();
     // We should have exactly 4 triangular faces
     assert_eq!(csg_tetra.polygons.len(), 4);
 }


### PR DESCRIPTION
Improve `Mesh::polyhedron` by using slices in place of vecs for flexibility and performence