### PR TITLE
Focus docs on function not implementation

### DIFF
--- a/src/mesh/manifold.rs
+++ b/src/mesh/manifold.rs
@@ -5,25 +5,19 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 impl<S: Clone + Debug + Send + Sync> Mesh<S> {
-    /// Checks if the Mesh object is manifold.
+    /// Checks if the Mesh object is manifold
     ///
-    /// This function defines a comparison function which takes EPSILON into account
-    /// for Real coordinates, builds a hashmap key from the string representation of
-    /// the coordinates, triangulates the Mesh polygons, gathers each of their three edges,
-    /// counts how many times each edge appears across all triangles,
-    /// and returns true if every edge appears exactly 2 times, else false.
+    /// ### Returns
+    /// Returns `true` if every edge appears exactly 2 times
     ///
-    /// We should also check that all faces have consistent orientation and no neighbors
+    /// ### Notes:
+    /// - This also checks that all faces have consistent orientation and no neighbors
     /// have flipped normals.
+    /// - This also checks for zero-area triangles
     ///
-    /// We should also check for zero-area triangles
-    ///
-    /// # Returns
-    ///
-    /// - `true`: If the Mesh object is manifold.
-    /// - `false`: If the Mesh object is not manifold.
+    /// - Uses a `QUANTIZATION_FACTOR` for `Real` coordinates
     pub fn is_manifold(&self) -> bool {
-        const QUANTIZATION_FACTOR: Real = 1e6;
+        const QUANTIZATION_FACTOR: Real = 1e7;
 
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         struct QuantizedPoint(i64, i64, i64);

--- a/src/mesh/metaballs.rs
+++ b/src/mesh/metaballs.rs
@@ -20,9 +20,10 @@ impl MetaBall {
         Self { center, radius }
     }
 
-	/// **Mathematical Foundation**: Metaball influence function I(p) = r²/(|p-c|² + ε)
-    /// where ε prevents division by zero and maintains numerical stability.
-    /// **Optimization**: Early termination for distant points and vectorized computation.
+    /// Finds the influence of a `Metaball` on point `p`
+    ///
+    /// #### Mathematical Foundation
+    /// Metaball influence function `I(p) = r²/(|p-c|² + ε)`
     pub fn influence(&self, p: &Point3<Real>) -> Real {
         let distance_squared = (p - self.center).norm_squared();
 
@@ -39,20 +40,22 @@ impl MetaBall {
     }
 }
 
-/// **Mathematical Foundation**: Scalar field F(p) = Σ I_i(p) where I_i is the influence
-/// function of the i-th metaball. This creates smooth isosurfaces at threshold values.
-/// **Optimization**: Iterator-based summation with potential for vectorization.
+/// Finds the total influence of all `Metaball`s on point `p`, this creates smooth isosurfaces at threshold values
+///
+/// #### Mathematical Foundation
+/// Scalar field `F(p) = Σ I_i(p)` where I_i is the influence function of the i-th metaball
 fn scalar_field_metaballs(balls: &[MetaBall], p: &Point3<Real>) -> Real {
     balls.iter().map(|ball| ball.influence(p)).sum()
 }
 
 impl<S: Clone + Debug + Send + Sync> Mesh<S> {
-    /// **Creates a Mesh from a list of metaballs** by sampling a 3D grid and using marching cubes.
+    /// Creates a Mesh from a list of metaballs, by sampling a 3D grid and using marching cubes.
     ///
+    /// ### Arguments
     /// - `balls`: slice of metaball definitions (center + radius).
     /// - `resolution`: (nx, ny, nz) defines how many steps along x, y, z.
     /// - `iso_value`: threshold at which the isosurface is extracted.
-    /// - `padding`: extra margin around the bounding region (e.g. 0.5) so the surface doesn't get truncated.
+    /// - `padding`: a small extra margin around the bounding region (e.g. 0.5) so the surface doesn't get truncated.
     pub fn metaballs(
         balls: &[MetaBall],
         resolution: (usize, usize, usize),

--- a/src/mesh/quality.rs
+++ b/src/mesh/quality.rs
@@ -47,7 +47,7 @@ pub struct TriangleQuality {
     pub quality_score: Real,
 }
 
-/// **Mathematical Foundation: Mesh Quality Assessment and Optimization**
+/// Mesh Quality Assessment and Optimization
 ///
 /// Advanced mesh processing algorithms for quality improvement:
 ///

--- a/src/mesh/sdf.rs
+++ b/src/mesh/sdf.rs
@@ -22,10 +22,8 @@ impl<S: Clone + Debug + Send + Sync> Mesh<S> {
     /// let max_pt = Point3::new( 2.0,  2.0,  2.0);
     /// let iso_value = 0.0; // Typically zero for SDF-based surfaces
     ///
-    ///    let mesh_shape = Mesh::from_sdf(my_sdf, resolution, min_pt, max_pt, iso_value);
-    ///
-    ///    // Now `mesh_shape` is your polygon mesh as a Mesh you can union, subtract, or export:
-    ///    let _ = std::fs::write("stl/sdf_sphere.stl", mesh_shape.to_stl_binary("sdf_sphere").unwrap());
+    /// let mesh_shape = Mesh::from_sdf(my_sdf, resolution, min_pt, max_pt, iso_value);
+    /// ```
     pub fn sdf<F>(
         sdf: F,
         resolution: (usize, usize, usize),


### PR DESCRIPTION
Focus docs on function not implementation by making the description simple.

## Why
Some of the current docs are vague on function and full of implementation description.

For example the `transform` docs does not need a section on Algorithm Complexity