### PR TITLE
Added code that allows for easier rendering of meshes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,18 +705,18 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -975,6 +975,7 @@ version = "0.20.1"
 dependencies = [
  "bevy_asset",
  "bevy_mesh",
+ "bytemuck",
  "chull",
  "contour_tracing",
  "core2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ js-sys = { version = "0.3.81", optional = true }
 serde-wasm-bindgen = { version = "0.6.5", optional = true }
 serde_json = { version = "1.0.145", optional = true }
 serde = { version = "1.0.228", optional = true }
+bytemuck = "1.24.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.18", features = ["js"] }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -20,7 +20,7 @@ use geo::{CoordsIter, Geometry, Polygon as GeoPolygon};
 use nalgebra::{
     Isometry3, Matrix4, Point3, Quaternion, Unit, Vector3, partial_max, partial_min,
 };
-use std::{cmp::PartialEq, collections::{HashMap}, fmt::Debug, num::NonZeroU32, sync::OnceLock};
+use std::{cmp::PartialEq, collections::HashMap, fmt::Debug, num::NonZeroU32, sync::OnceLock};
 
 #[cfg(feature = "parallel")]
 use rayon::{iter::IntoParallelRefIterator, prelude::*};
@@ -55,7 +55,7 @@ pub type GraphicsMeshVertex = ([f32; 3], [f32; 3]);
 /// normals.
 #[derive(Debug, Clone)]
 pub struct GraphicsMesh {
-    /// Vertices contain both position and normal 
+    /// Vertices contain both position and normal
     pub vertices: Vec<GraphicsMeshVertex>,
     pub indices: Vec<u32>,
 }
@@ -262,8 +262,9 @@ impl<S: Clone + Send + Sync + Debug> Mesh<S> {
 
         let mut indices: Vec<u32> = Vec::with_capacity(triangle_count);
         let mut vertices: Vec<GraphicsMeshVertex> = Vec::with_capacity(triangle_count);
-        const VERT_DIM_SIZE: usize = std::mem::size_of::<[f32;3]>();
-        let mut vertices_hash: HashMap<([u8; VERT_DIM_SIZE], [u8; VERT_DIM_SIZE]), u32> = HashMap::with_capacity(triangle_count);
+        const VERT_DIM_SIZE: usize = std::mem::size_of::<[f32; 3]>();
+        let mut vertices_hash: HashMap<([u8; VERT_DIM_SIZE], [u8; VERT_DIM_SIZE]), u32> =
+            HashMap::with_capacity(triangle_count);
 
         let mut i_new_vertex: u32 = 0;
 
@@ -280,8 +281,8 @@ impl<S: Clone + Send + Sync + Debug> Mesh<S> {
                 let pos_xyz = [pos_x, pos_y, pos_z];
                 let norm_xyz = [norm_x, norm_y, norm_z];
 
-                let pos_xyz_bytes: [u8; std::mem::size_of::<[f32;3]>()] = cast(pos_xyz);
-                let norm_xyz_bytes: [u8; std::mem::size_of::<[f32;3]>()] = cast(norm_xyz);
+                let pos_xyz_bytes: [u8; std::mem::size_of::<[f32; 3]>()] = cast(pos_xyz);
+                let norm_xyz_bytes: [u8; std::mem::size_of::<[f32; 3]>()] = cast(norm_xyz);
 
                 let vertex_f32 = (pos_xyz, norm_xyz);
                 let vertex_f32_bytes = (pos_xyz_bytes, norm_xyz_bytes);
@@ -291,7 +292,7 @@ impl<S: Clone + Send + Sync + Debug> Mesh<S> {
                 } else {
                     vertices_hash.insert(vertex_f32_bytes, i_new_vertex);
                     vertices.push(vertex_f32);
-                    
+
                     indices.push(i_new_vertex);
 
                     i_new_vertex += 1;
@@ -301,10 +302,7 @@ impl<S: Clone + Send + Sync + Debug> Mesh<S> {
 
         vertices.shrink_to_fit();
 
-        GraphicsMesh {
-            vertices,
-            indices
-        }
+        GraphicsMesh { vertices, indices }
     }
 
     /// Extracts vertices and indices from the Mesh's tessellated polygons.
@@ -327,7 +325,6 @@ impl<S: Clone + Send + Sync + Debug> Mesh<S> {
 
         (vertices, indices)
     }
-
 
     /// Casts a ray defined by `origin` + t * `direction` against all triangles
     /// of this Mesh and returns a list of (intersection_point, distance),

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -258,8 +258,6 @@ impl<S: Clone + Send + Sync + Debug> Mesh<S> {
 
         let triangle_count = triangles.len();
 
-        //let crc_hasher = BuildCrcHasher::default();
-
         let mut indices: Vec<u32> = Vec::with_capacity(triangle_count);
         let mut vertices: Vec<GraphicsMeshVertex> = Vec::with_capacity(triangle_count);
         const VERT_DIM_SIZE: usize = std::mem::size_of::<[f32; 3]>();


### PR DESCRIPTION
I've found that in order to render triangulated meshes, it is necessary to do the following operations:

 * Convert all f64s to f32s
 * Remove redundant vertices and generate indices for rendering

The end user could do this themselves but adding a function that does that for them would make things easier.

I added the `GraphicsMesh` type which contains all the info needed to render the mesh(not including texture data)
and the `build_graphics_mesh()` function to the Mesh type. It does perform a bit of calculation; it takes 40ms to convert around 119,988 triangles. But it uses about 40% less vram vs directly drawing triangles. It's not likely that this conversion function will be the bottleneck of a rendering pipeline.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new `GraphicsMesh` type and `build_graphics_mesh()` method to simplify rendering of triangulated meshes. The function handles converting vertices from `f64` to `f32` precision and removes redundant vertices by generating an indexed representation, which reduces VRAM usage by approximately 40% at the cost of a one-time conversion overhead (40ms for ~120k triangles). The changes add the `bytemuck` dependency for safe type casting between numeric types.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
| 3 | `src/mesh/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->