### PR TITLE
Replace core2 with std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,15 +868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,7 +941,6 @@ dependencies = [
  "boolmesh",
  "chull",
  "contour_tracing",
- "core2",
  "doc-image-embed",
  "dxf",
  "earcutr 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,6 @@ base64 = { version = "0.22", optional = true }
 #doc-image-embed = "0.2" # fork of https://crates.io/crates/embed-doc-image - should be upstreamed.
 
 # io/load
-# core2 = { version = "0.4.0", default_features = false, features = ["alloc"] } # no-std, still throws errors
-core2 = { version = "0.4", features = ["alloc"] }
 dxf = { version = "0.6", optional = true }
 stl_io = { version = "0.8", optional = true }
 image = { version = "0.25", optional = true }

--- a/src/io/dxf.rs
+++ b/src/io/dxf.rs
@@ -9,7 +9,7 @@ use nalgebra::{Point3, Vector3};
 use std::error::Error;
 use std::fmt::Debug;
 
-use core2::io::Cursor;
+use std::io::Cursor;
 use dxf::Drawing;
 use dxf::entities::*;
 

--- a/src/io/stl.rs
+++ b/src/io/stl.rs
@@ -1,6 +1,6 @@
 use crate::triangulated::Triangulated3D;
 use std::fmt::Debug;
-use core2::io::Cursor;
+use std::io::Cursor;
 use stl_io;
 
 /// Export to ASCII STL


### PR DESCRIPTION
The core2 cargo was [deprecated](https://crates.io/crates/core2) on 4/15. No reason to use since the same functionality is available from std.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes the deprecated `core2` dependency and replaces it with the standard library's equivalent functionality. The change updates the import statements from `core2::io::Cursor` to `std::io::Cursor` in the DXF and STL I/O modules, and removes the `core2` dependency from both Cargo manifest files.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
| 3 | `src/io/dxf.rs` |
| 4 | `src/io/stl.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->